### PR TITLE
Add a repo link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Render React.js components on any backend",
   "bin": "./bin/react-stdio",
   "preferGlobal": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mjackson/react-stdio"
+  },
   "files": [
     "bin",
     "server.js"


### PR DESCRIPTION
When installing locally was getting a warning that `repository` field was missing in `package.json`:
<img width="527" alt="mj" src="https://cloud.githubusercontent.com/assets/1126672/12100629/12be39c4-b328-11e5-8c89-4ef140d9eb50.png">

- Added the `repository` field.
- Re-ran `npm install`
- asserted that no warnings were shown. 