### PR TITLE
Explicitly 'use strict';

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+'use strict';
 const path = require('path')
 const invariant = require('invariant')
 const EventStream = require('event-stream')
@@ -112,7 +113,10 @@ Object.defineProperty(process, 'stdout', {
 
 // Ensure console.log knows about the new stdout.
 const Console = require('console').Console
-console = new Console(process.stdout, process.stderr)
+const stdioConsole = new Console(process.stdout, process.stderr);
+Object.keys(stdioConsole).forEach(function(key) {
+  console[key] = stdioConsole[key];
+});
 
 // Read JSON blobs from stdin, pipe output to stdout.
 process.stdin

--- a/server.js
+++ b/server.js
@@ -113,10 +113,11 @@ Object.defineProperty(process, 'stdout', {
 
 // Ensure console.log knows about the new stdout.
 const Console = require('console').Console
-const stdioConsole = new Console(process.stdout, process.stderr);
-Object.keys(stdioConsole).forEach(function(key) {
-  console[key] = stdioConsole[key];
-});
+Object.defineProperty(global, 'console', {
+  configurable: true,
+  enumerable: true,
+  value: new Console(process.stdout, process.stderr)
+})
 
 // Read JSON blobs from stdin, pipe output to stdout.
 process.stdin


### PR DESCRIPTION
Hey @mjackson! Thanks a ton for this project, it's been a lot of fun to play around with! :+1:

I just upgraded to `react-stdio v3.0.0` and started seeing some issues. It looks like for my version of node (`v4.3.2`) the new `let`/`const` declarations are causing errors outside strict mode. Here's what I'm seeing:

```
$ ./node_modules/.bin/react-stdio 
/Users/mattwondra/projects/atcms/node_modules/react-stdio/server.js:41
  let render
  ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/mattwondra/projects/atcms/node_modules/react-stdio/bin/react-stdio:2:1)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
```

It's possible that there's something else I could/should be doing to address this, so please let me know if so. But otherwise it seems to make sense to explicitly `'use strict';` at the top of the server module.

Adding that fixed the original error, but exposed another:

```
$ ./node_modules/.bin/react-stdio 
/Users/mattwondra/projects/atcms/node_modules/react-stdio/server.js:116
console = new Console(process.stdout, process.stderr)
        ^

TypeError: Cannot set property console of #<Object> which has only a getter
    at Object.<anonymous> (/Users/mattwondra/projects/atcms/node_modules/react-stdio/server.js:116:9)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/mattwondra/projects/atcms/node_modules/react-stdio/bin/react-stdio:2:1)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
```

Again, I'm not sure if there's something else to combat this (I'm not well-versed in node best practices), but it seemed reasonable to me instead to iterate over the properties of the new `Console` object and place them on the standard `console` object, rather than trying to change the ref with `=`.

Let me know if I can clarify or offer any other info on this! This is actually my first open-source PR so I'm excited to get it out there, even if there ends up being a better way to solve these issues.

Thanks!
